### PR TITLE
add cli functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+
+PROGRAM         := generate-mermaid.py
+HISTORY_URL     := https://raw.githubusercontent.com/temporal-sa/temporal-money-transfer-java/refs/heads/main/workflowHistories/happy-path-ui-decoded.json
+HISTORY_FILE    := workflows_history/happy_path.json
+MERMAID_FILE    := mermaid_diagrams/happy_path.mmd
+
+help:
+	@awk 'BEGIN {FS = ":.*?## "} /^[^: ]+:.*?## / {printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
+setup-testing: ## prepare test env
+	mkdir -p workflows_history mermaid_diagrams
+	[ -f "$(HISTORY_FILE)" ] || curl -sL $(HISTORY_URL) > $(HISTORY_FILE)
+
+test: setup-testing  ## run tests
+	python $(PROGRAM) -f  $(HISTORY_FILE) | grep -q '^graph TD;'
+	rm -f $(MERMAID_FILE)
+	python $(PROGRAM) && grep -q '^graph TD;' $(MERMAID_FILE)
+	rm -f $(MERMAID_FILE)
+	python $(PROGRAM) -w workflows_history -m mermaid_diagrams && grep -q '^graph TD;' $(MERMAID_FILE)
+
+

--- a/generate-mermaid.py
+++ b/generate-mermaid.py
@@ -1,7 +1,14 @@
 # -*- coding: utf-8 -*-
+import argparse
 import json
+import logging
 import os
+import sys
 from typing import List, Dict
+
+logging.basicConfig(level=logging.INFO, stream=sys.stderr,
+                    format='%(asctime)s - %(levelname)s - %(message)s')
+
 
 # Configuration constants
 OUTPUT_EVENTS_ID = False
@@ -9,8 +16,10 @@ SCHEDULED_COLOR = "#f9f"
 COMPLETED_COLOR = "#bbf"
 ACTIVITY_COLOR = "#C8E6C9"  # Color for activity
 NEXUS_STYLE_COLOR = "#FFF9C4"  # Specific color for styling Nexus tasks
-WORKFLOWS_DIR = "workflows_history"
-OUTOUT_DIR = "mermaid_diagrams"
+WORKFLOWS_DIR = os.getenv("WORKFLOWS_DIR", "workflows_history")
+MERMAID_DIR = os.getenv("MERMAID_DIR", "mermaid_diagrams")
+
+
 
 def escape_string(s):
     """
@@ -35,9 +44,9 @@ def generate_mermaid_code(event_data):
             event_id = event["eventId"]
             event_time = event["eventTime"]
             activity_name = event["activityTaskScheduledEventAttributes"]["activityType"]["name"]
-        
+
             input_data = event["activityTaskScheduledEventAttributes"]["input"]["payloads"][0]["data"]
-            
+
             scheduled_task_id = "Task{}".format(task_index)
             activity_ids.append(scheduled_task_id)  # Track the activity task ID
 
@@ -47,19 +56,19 @@ def generate_mermaid_code(event_data):
                 mermaid_code.append('eventId{}["eventId: {}"]'.format(event_count, escape_string(str(event_id))))
                 mermaid_code.append('eventTime{}["eventTime: {}"]'.format(event_count, escape_string(event_time)))
             mermaid_code.append('activityTypeName{}["activityType.name: {}"]'.format(event_count, escape_string(activity_name)))
-            
+
             input_subgraph = "InputData{}".format(event_count)
             mermaid_code.append('subgraph {}["Input Fields"]'.format(input_subgraph))
-            
+
             if isinstance(input_data, dict):
                 for key in input_data.keys():
                     mermaid_code.append('{}{}["{}"]'.format(key, event_count, escape_string(key)))
             else:
                 mermaid_code.append('inputData{}["{}"]'.format(event_count, escape_string(str(input_data))))
-            
+
             mermaid_code.append("end")
             mermaid_code.append("end")
-            
+
             event_count += 1
 
             # Connect previous task to this one
@@ -74,7 +83,7 @@ def generate_mermaid_code(event_data):
                     completed_event_id = completed_event["eventId"]
                     completed_event_time = completed_event["eventTime"]
                     output_data = completed_event["activityTaskCompletedEventAttributes"].get("result", {}).get("payloads", [{}])[0].get("data", {})
-                    
+
                     completed_task_id = "CompletedTask{}".format(task_index)
                     activity_ids.append(completed_task_id)  # Track the activity task ID
 
@@ -83,19 +92,19 @@ def generate_mermaid_code(event_data):
                     if OUTPUT_EVENTS_ID:
                         mermaid_code.append('eventId{}["eventId: {}"]'.format(event_count, escape_string(str(completed_event_id))))
                         mermaid_code.append('eventTime{}["eventTime: {}"]'.format(event_count, escape_string(completed_event_time)))
-                    
+
                     output_subgraph = "OutputData{}".format(event_count)
                     mermaid_code.append('subgraph {}["Output Fields"]'.format(output_subgraph))
-                    
+
                     if isinstance(output_data, dict):
                         for key in output_data.keys():
                             mermaid_code.append('{}{}["{}"]'.format(key, event_count, escape_string(key)))
                     else:
                         mermaid_code.append('outputData{}["{}"]'.format(event_count, escape_string(str(output_data))))
-                    
+
                     mermaid_code.append("end")
                     mermaid_code.append("end")
-                    
+
                     # Connect scheduled task to completed task
                     mermaid_code.append("{} --> {}".format(scheduled_task_id, completed_task_id))
 
@@ -104,7 +113,7 @@ def generate_mermaid_code(event_data):
                     break
 
             task_index += 1
-        
+
         # Handle Nexus operation scheduled
         elif event["eventType"] == "EVENT_TYPE_NEXUS_OPERATION_SCHEDULED":
             event_id = event.get("eventId", "")
@@ -112,7 +121,7 @@ def generate_mermaid_code(event_data):
             endpoint = nexus_attributes.get("endpoint", "")
             service = nexus_attributes.get("service", "")
             operation = nexus_attributes.get("operation", "")
-            
+
             # Only add NexusScheduled if it contains meaningful data (endpoint, service, operation)
             if endpoint or service or operation:
                 nexus_task_id_scheduled = "NexusScheduled{}".format(task_index)
@@ -138,7 +147,7 @@ def generate_mermaid_code(event_data):
         elif event["eventType"] == "EVENT_TYPE_NEXUS_OPERATION_STARTED":
             event_id = event.get("eventId", "")
             operation_id = event["nexusOperationStartedEventAttributes"].get("operationId", "")
-            
+
             # Only add NexusStart if operationId is valid
             if operation_id:
                 nexus_task_id = "NexusStart{}".format(task_index)
@@ -163,7 +172,7 @@ def generate_mermaid_code(event_data):
         elif event["eventType"] == "EVENT_TYPE_NEXUS_OPERATION_COMPLETED":
             event_id = event.get("eventId", "")
             scheduled_event_id = event["nexusOperationCompletedEventAttributes"].get("scheduledEventId", "")
-            
+
             # Ensure NexusComplete and NexusScheduled are valid
             if scheduled_event_id:
                 nexus_complete_id = "NexusComplete{}".format(scheduled_event_id)
@@ -171,13 +180,13 @@ def generate_mermaid_code(event_data):
 
                 mermaid_code.append('subgraph {}["Nexus Operation Completed: {}"]'.format(nexus_complete_id, escape_string(scheduled_event_id)))
                 mermaid_code.append("class {} nexus;".format(nexus_complete_id))
-                
+
                 if OUTPUT_EVENTS_ID:
                     mermaid_code.append('eventId{}["eventId: {}"]'.format(event_count, escape_string(str(event_id))))
-                
+
                 mermaid_code.append("end")
                 event_count += 1
-                
+
                 # Ensure sequential linking for Nexus tasks
                 if last_nexus_task_id:
                     mermaid_code.append("{} --> {}".format(last_nexus_task_id, nexus_complete_id))
@@ -197,20 +206,47 @@ def generate_mermaid_code(event_data):
 
     return "\n".join(mermaid_code)
 
-def process_workflows():
-    for filename in os.listdir(WORKFLOWS_DIR):
+
+def process_workflows(input_dir, output_dir):
+    for filename in os.listdir(input_dir):
         if filename.endswith(".json"):
-            file_path = os.path.join(WORKFLOWS_DIR, filename)
-            with open(file_path, 'r') as file:
-                event_data = json.load(file)
-                try:
-                    mermaid_code = generate_mermaid_code(event_data)
-                    output_file = os.path.join(OUTOUT_DIR, "{}.mmd".format(filename[:-5]))
-                    with open(output_file, 'w') as mermaid_file:
-                        mermaid_file.write(mermaid_code)
-                    print("Generated Mermaid code for {} at {}".format(filename, output_file))
-                except Exception as e:
-                    print("Error processing {}: {}".format(filename, e))
+            file_path = os.path.join(input_dir, filename)
+            output_file = os.path.join(output_dir, "{}.mmd".format(filename[:-5]))
+            process_history(file_path, output_file)
+            logging.info("mermaid generated src={} dest={}".format(file_path, output_file))
+
+def process_history(input_file, output_file):
+    """ process """
+    with open(input_file, 'r') as file:
+        try:
+            event_data = json.load(file)
+            mermaid_code = generate_mermaid_code(event_data)
+            if output_file == "-" or output_file is None:
+                print(mermaid_code)
+            else:
+                with open(output_file, 'w') as mermaid_file:
+                    mermaid_file.write(mermaid_code)
+        except Exception as e:
+            logging.error("Error processing {}: {}".format(input_file, e))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+                prog='GenerateMermaid',
+                description='Generate Mermaid output from a Temporal history JSON. Use on either a single JSON file or on a directory of JSON histories.',
+                epilog='Additional effective env vars: WORKFLOWS_DIR MERMAID_DIR')
+    parser.add_argument('-f', '--file')
+    parser.add_argument('-o', '--out')
+    parser.add_argument('-w', '--workflows-dir')
+    parser.add_argument('-m', '--mermaid-dir')
+
+    args = parser.parse_args()
+    input_dir = args.workflows_dir or WORKFLOWS_DIR
+    output_dir = args.mermaid_dir or MERMAID_DIR
+    if args.file:
+        process_history(args.file, args.out)
+    else:
+        process_workflows(input_dir, output_dir)
 
 if __name__ == "__main__":
-    process_workflows()
+    main()


### PR DESCRIPTION
Enhancements to make this great tool a more useful CLI. 
Includes a new Makefile to provide basic sanity via `make test`.

Before, the CLI was limited: one must have prescribed default directories in current work dir.

After:
- allow override of input dir via env `WORKFLOWS_DIR` or flags `-w` (short)  `--workflows-dir` (long)
- allows override of output dir via env `MERMAID_DIR` or flags `-m` (short) `--mermaid-dir` (long)
- allows single file processing mode via flag `-f` (short) `--file` (long). 
- in single file processing mode, output to file via flag `-o` (short) `--out` (long).
- in single processing mode if no output defined, prints to STDOUT

Additionally:
- proper logging to STDERR.
- whitespace fixups
